### PR TITLE
Add comments to semantic analysis.

### DIFF
--- a/src/mkdocstrings_handlers/asp/document.py
+++ b/src/mkdocstrings_handlers/asp/document.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass, field
 
 from tree_sitter import Tree
 
+from mkdocstrings_handlers.asp.semantics.block_comment import BlockComment
 from mkdocstrings_handlers.asp.semantics.collector import Collector
+from mkdocstrings_handlers.asp.semantics.line_comment import LineComment
 from mkdocstrings_handlers.asp.semantics.statement import Statement
 from mkdocstrings_handlers.asp.tree_sitter.parser import ASPParser
 
@@ -19,6 +21,8 @@ class Document:
     content: str
     tree: Tree
     statements: list[Statement] = field(default_factory=list)
+    line_comments: list[LineComment] = field(default_factory=list)
+    block_comments: list[BlockComment] = field(default_factory=list)
 
     @staticmethod
     def new(title: str, content: str) -> Document:
@@ -36,7 +40,6 @@ class Document:
         # Parse content to tree
         parser = ASPParser()
         tree = parser.parse(content)
-
         # Collect data from tree
         collector = Collector()
         collector.collect(tree)
@@ -46,4 +49,6 @@ class Document:
             content=content,
             tree=tree,
             statements=collector.statements,
+            line_comments=collector.line_comments,
+            block_comments=collector.block_comments,
         )

--- a/src/mkdocstrings_handlers/asp/semantics/block_comment.py
+++ b/src/mkdocstrings_handlers/asp/semantics/block_comment.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tree_sitter import Node
+
+
+@dataclass
+class BlockComment:
+    """A block comment in an ASP document."""
+
+    row: int
+    """ The row of the block comment. """
+    lines: list[str]
+    """ The lines of text of the block comment. """
+
+    @staticmethod
+    def from_node(node: Node) -> BlockComment:
+        """
+        Create a block comment from a node.
+        """
+        clean_text = node.text.decode("utf-8").removeprefix("%*").removesuffix("*%").strip()
+        lines = clean_text.split("\n")
+
+        return BlockComment(row=node.start_point.row, lines=lines)

--- a/src/mkdocstrings_handlers/asp/semantics/collector.py
+++ b/src/mkdocstrings_handlers/asp/semantics/collector.py
@@ -1,5 +1,7 @@
 from tree_sitter import Node
 
+from mkdocstrings_handlers.asp.semantics.block_comment import BlockComment
+from mkdocstrings_handlers.asp.semantics.line_comment import LineComment
 from mkdocstrings_handlers.asp.semantics.literal import Literal
 from mkdocstrings_handlers.asp.tree_sitter.node_kind import NodeKind
 from mkdocstrings_handlers.asp.tree_sitter.traverse import traverse
@@ -23,6 +25,8 @@ class Collector:
 
         # data
         self.statements: list[Statement] = []
+        self.line_comments: list[LineComment] = []
+        self.block_comments: list[BlockComment] = []
 
     def collect(self, tree):
         """
@@ -61,6 +65,12 @@ class Collector:
                     statement.add_provided(literal)
                 else:
                     statement.add_needed(literal)
+            case NodeKind.LINE_COMMENT:
+                line_comment = LineComment.from_node(node)
+                self.line_comments.append(line_comment)
+            case NodeKind.BLOCK_COMMENT:
+                block_comment = BlockComment.from_node(node)
+                self.block_comments.append(block_comment)
             case _:
                 pass
 

--- a/src/mkdocstrings_handlers/asp/semantics/line_comment.py
+++ b/src/mkdocstrings_handlers/asp/semantics/line_comment.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tree_sitter import Node
+
+
+@dataclass
+class LineComment:
+    """A line comment in an ASP document."""
+
+    row: int
+    """ The row of the line comment. """
+    line: str
+    """ The line of text of the comment. """
+
+    @staticmethod
+    def from_node(node: Node) -> LineComment:
+        """
+        Create a line comment from a node.
+        """
+        clean_text = node.text.decode("utf-8").removeprefix("%").strip()
+
+        return LineComment(row=node.start_point.row, line=clean_text)

--- a/src/mkdocstrings_handlers/asp/tree_sitter/node_kind.py
+++ b/src/mkdocstrings_handlers/asp/tree_sitter/node_kind.py
@@ -12,6 +12,8 @@ class NodeKind(Enum):
     BODY = "body"
     SYMBOLIC_ATOM = "symbolic_atom"
     LITERAL_TUPLE = "literal_tuple"
+    LINE_COMMENT = "line_comment"
+    BLOCK_COMMENT = "block_comment"
 
     @staticmethod
     def from_grammar_name(grammar_name: str):


### PR DESCRIPTION
This adds Line- and Block-Comments to the analysis. For now, each simply contain their starting `row` and the `lines` of text they consist of as cleaned up strings.