### PR TITLE
12 add predicate documentation

### DIFF
--- a/src/mkdocstrings_handlers/asp/document.py
+++ b/src/mkdocstrings_handlers/asp/document.py
@@ -7,6 +7,7 @@ from tree_sitter import Tree
 from mkdocstrings_handlers.asp.semantics.block_comment import BlockComment
 from mkdocstrings_handlers.asp.semantics.collector import Collector
 from mkdocstrings_handlers.asp.semantics.line_comment import LineComment
+from mkdocstrings_handlers.asp.semantics.predicate_documentation import PredicateDocumentation
 from mkdocstrings_handlers.asp.semantics.statement import Statement
 from mkdocstrings_handlers.asp.tree_sitter.parser import ASPParser
 
@@ -23,6 +24,7 @@ class Document:
     statements: list[Statement] = field(default_factory=list)
     line_comments: list[LineComment] = field(default_factory=list)
     block_comments: list[BlockComment] = field(default_factory=list)
+    predicate_documentations: list[PredicateDocumentation] = field(default_factory=list)
 
     @staticmethod
     def new(title: str, content: str) -> Document:
@@ -51,4 +53,5 @@ class Document:
             statements=collector.statements,
             line_comments=collector.line_comments,
             block_comments=collector.block_comments,
+            predicate_documentations=collector.predicate_documentations,
         )

--- a/src/mkdocstrings_handlers/asp/semantics/collector.py
+++ b/src/mkdocstrings_handlers/asp/semantics/collector.py
@@ -3,6 +3,7 @@ from tree_sitter import Node
 from mkdocstrings_handlers.asp.semantics.block_comment import BlockComment
 from mkdocstrings_handlers.asp.semantics.line_comment import LineComment
 from mkdocstrings_handlers.asp.semantics.literal import Literal
+from mkdocstrings_handlers.asp.semantics.predicate_documentation import PredicateDocumentation
 from mkdocstrings_handlers.asp.tree_sitter.node_kind import NodeKind
 from mkdocstrings_handlers.asp.tree_sitter.traverse import traverse
 
@@ -27,6 +28,7 @@ class Collector:
         self.statements: list[Statement] = []
         self.line_comments: list[LineComment] = []
         self.block_comments: list[BlockComment] = []
+        self.predicate_documentations: list[PredicateDocumentation] = []
 
     def collect(self, tree):
         """
@@ -71,6 +73,12 @@ class Collector:
             case NodeKind.BLOCK_COMMENT:
                 block_comment = BlockComment.from_node(node)
                 self.block_comments.append(block_comment)
+
+                # Predicate documentation
+                predicate_documentation = PredicateDocumentation.from_block_comment(block_comment)
+                if predicate_documentation is not None:
+                    self.predicate_documentations.append(predicate_documentation)
+
             case _:
                 pass
 

--- a/src/mkdocstrings_handlers/asp/semantics/literal.py
+++ b/src/mkdocstrings_handlers/asp/semantics/literal.py
@@ -7,14 +7,31 @@ from tree_sitter import Node
 
 @dataclass
 class Literal:
+    """A literal in an ASP document."""
+
     identifier: str
+    """ The identifier of the literal. """
     arity: int
+    """ The arity (number of parameters) of the literal. """
     negation: bool
+    """ Whether the literal is negated. """
+    text: str
+    """ Plain ASP text of the literal. """
 
     @staticmethod
     def from_node(node: Node) -> Literal:
-        # If the literal has a single child, it is positive
+        """
+        Create a literal from a node.
 
+        Args:
+            node: The node representing the literal.
+
+        Returns:
+            The created literal.
+        """
+        text = node.text.decode("utf-8")
+
+        # If the literal has a single child or is double-negated, it is positive
         negation = node.child_count > 1 and node.children[0].child_count == 1
 
         atom = node.children[0] if node.child_count == 1 else node.children[1]
@@ -27,4 +44,4 @@ class Literal:
             terms = atom.children[1].children[0]
             arity = len(terms.children) // 2
 
-        return Literal(identifier, arity, negation)
+        return Literal(identifier, arity, negation, text)

--- a/src/mkdocstrings_handlers/asp/semantics/predicate_documentation.py
+++ b/src/mkdocstrings_handlers/asp/semantics/predicate_documentation.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from tree_sitter import Node
+
+from mkdocstrings_handlers.asp.semantics.block_comment import BlockComment
+from mkdocstrings_handlers.asp.semantics.literal import Literal
+from mkdocstrings_handlers.asp.tree_sitter.debug import print_tree
+from mkdocstrings_handlers.asp.tree_sitter.node_kind import NodeKind
+from mkdocstrings_handlers.asp.tree_sitter.parser import ASPParser
+from mkdocstrings_handlers.asp.tree_sitter.traverse import traverse
+
+
+@dataclass
+class PredicateDocumentation:
+    """
+    Documentation for a predicate.
+
+
+    Example:
+        %*#some_predicate(B,A,C).
+        description
+        #parameters
+        - A : this is  A
+        - B : this is  B
+        - C : this is  C
+        *%
+    """
+
+    literal: Literal
+    """ The literal representing the predicate. """
+    description: str
+    """ The description of the predicate. """
+    parameter_descriptions: dict[str, str] = field(default_factory=dict)
+    """ The descriptions of the parameters of the predicate. """
+
+    @staticmethod
+    def from_block_comment(comment: BlockComment) -> PredicateDocumentation | None:
+        """
+        Create a predicate documentation from a comment.
+
+        Args:
+            comment: The block comment.
+
+        Returns:
+            The predicate documentation or None if the comment is not a predicate documentation.
+        """
+        if not comment.lines[0].startswith("#"):
+            return None
+
+        # Get the signature
+        signature = comment.lines[0].removeprefix("#").strip()
+
+        # Parse the signature to get the literal
+        literal = None
+
+        def identifier_from_node(node: Node):
+            nonlocal literal
+            if NodeKind.from_grammar_name(node.grammar_name) == NodeKind.SYMBOLIC_ATOM:
+                literal = Literal.from_node(node.parent)
+
+        parser = ASPParser()
+        tree = parser.parse(signature)
+        traverse(tree, identifier_from_node, lambda _: None)
+
+        # Get the description
+        description_lines = []
+
+        for line in comment.lines[1:]:
+            if line.startswith("#parameters"):
+                description = line.removeprefix("#").strip()
+                break
+            description_lines.append(line)
+
+        description = "\n".join(description_lines)
+        parameters = []
+        parameter_descriptions = {}
+        for line in comment.lines[len(description_lines) :]:
+            if line.startswith("-"):
+                parts = line.removeprefix("-").split(":")
+                if len(parts) == 2:
+                    parameter, parameter_description = parts
+                    parameters.append(parameter.strip())
+                    parameter_descriptions[parameter.strip()] = parameter_description.strip()
+
+        return PredicateDocumentation(
+            literal=literal, description=description, parameter_descriptions=parameter_descriptions
+        )


### PR DESCRIPTION
This adds `PredicateDocumentation`, collecting data from doc-strings into this documentation type for later use.

It also adds the field `text` to `Literal` which represents the source code of the specific instance of the `Literal`.