### PR TITLE
add tracking of include and show signature directives

### DIFF
--- a/examples/sudoku/encoding.lp
+++ b/examples/sudoku/encoding.lp
@@ -1,3 +1,4 @@
+#include "some_included_file.lp"
 #const dim = 3.
 val(1..dim*dim).
 pos(X,Y) :- val(X), val(Y).
@@ -54,3 +55,5 @@ subgrid(X,Y,(((X-1)/dim)*dim+((Y-1)/dim))) :- pos(X,Y).
 :- sudoku(X,Y,V), sudoku(X',Y',V), subgrid(X,Y,S), subgrid(X',Y',S), (X,Y)!=(X',Y').
 
 sudoku(X,Y,V) :- initial(X,Y,V).
+
+#show sudoku/3.

--- a/src/mkdocstrings_handlers/asp/semantics/collector.py
+++ b/src/mkdocstrings_handlers/asp/semantics/collector.py
@@ -7,6 +7,8 @@ including statements, comments and predicates.
 from tree_sitter import Node
 
 from mkdocstrings_handlers.asp.semantics.block_comment import BlockComment
+from mkdocstrings_handlers.asp.semantics.directives.include import Include
+from mkdocstrings_handlers.asp.semantics.directives.show_signature import ShowSignature
 from mkdocstrings_handlers.asp.semantics.line_comment import LineComment
 from mkdocstrings_handlers.asp.semantics.predicate import Predicate
 from mkdocstrings_handlers.asp.semantics.predicate_documentation import PredicateDocumentation
@@ -35,6 +37,7 @@ class Collector:
         self.line_comments: list[LineComment] = []
         self.block_comments: list[BlockComment] = []
         self.predicates: dict[str, Predicate] = {}
+        self.includes: list[Include] = []
 
     def collect(self, tree):
         """
@@ -99,6 +102,12 @@ class Collector:
                 predicate.documentation = predicate_documentation
                 predicate.documentation.node = None
 
+            case NodeKind.SHOW_SIGNATURE:
+                ShowSignature.from_node(node)
+
+            case NodeKind.INCLUDE:
+                include = Include.from_node(node)
+                self.includes.append(include)
             case _:
                 pass
 

--- a/src/mkdocstrings_handlers/asp/semantics/directives/include.py
+++ b/src/mkdocstrings_handlers/asp/semantics/directives/include.py
@@ -1,0 +1,37 @@
+""" This module contains the representation of an include directive in ASP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tree_sitter import Node
+
+
+@dataclass
+class Include:
+    """An include directive in an ASP document."""
+
+    path: str
+    """ The path of the included file."""
+
+    @staticmethod
+    def from_node(node: Node) -> Include:
+        """
+        Create an Include from the given node.
+
+        Args:
+            node: The node.
+
+        Returns:
+            The created Include.
+        """
+        # If the node is an include,
+        # then the first child is the include directive
+        # and the second child is the file path.
+
+        # The second child of the file path is the file path
+        # as a string fragment without the quotes.
+        file_path_node = node.children[1]
+        file_path = file_path_node.children[1].text.decode("utf-8")
+
+        return Include(file_path)

--- a/src/mkdocstrings_handlers/asp/semantics/directives/show_signature.py
+++ b/src/mkdocstrings_handlers/asp/semantics/directives/show_signature.py
@@ -1,0 +1,34 @@
+""" This module contains the representation of a show signature directive in ASP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tree_sitter import Node
+
+
+@dataclass
+class ShowSignature:
+    """A show signature directive in an ASP document."""
+
+    signature: str
+    """ The signature of the show directive."""
+
+    @staticmethod
+    def from_node(node: Node) -> ShowSignature:
+        """
+        Create a ShowSignature from the given node.
+
+        Args:
+            node: The node.
+
+        Returns:
+            The created ShowSignature.
+        """
+        # If the node is a show_signature,
+        # then the first child is the show directive
+        # and the second child is the signature.
+
+        signature = node.children[1].text.decode("utf-8")
+
+        return ShowSignature(signature)

--- a/src/mkdocstrings_handlers/asp/tree_sitter/node_kind.py
+++ b/src/mkdocstrings_handlers/asp/tree_sitter/node_kind.py
@@ -16,6 +16,8 @@ class NodeKind(Enum):
     LITERAL_TUPLE = "literal_tuple"
     LINE_COMMENT = "line_comment"
     BLOCK_COMMENT = "block_comment"
+    SHOW_SIGNATURE = "show_signature"
+    INCLUDE = "include"
 
     @staticmethod
     def from_grammar_name(grammar_name: str):


### PR DESCRIPTION
This adds tracking of `#include` and `#show` directives. For now only `#show` directives of the form `#show identifier/arity` are supported, other variations have to be discussed first.