### PR TITLE
add short summary for use in predicate table

### DIFF
--- a/examples/config/base/discrete.lp
+++ b/examples/config/base/discrete.lp
@@ -1,11 +1,11 @@
 % Generate exactly one value for each discrete attribute if it is included
 { value(X,V) : domain(T,V) } = 1 :- include(X), type(X,T), discrete(T).
 
-% { value(X,O) : type(X,T), enumeration(T), option(T,O) } 1.
+% % { value(X,O) : type(X,T), enumeration(T), option(T,O) } 1.
 % % No value if variable has not been included
-% :- type(X,T), value(X,_),  not include(X).
+% % :- type(X,T), value(X,_),  not include(X).
 % % Exactly one value if variable has been included
-% :- attribute(T,_), type(X,T), include(X), not { value(X,_) } = 1.
+% % :- attribute(T,_), type(X,T), include(X), not { value(X,_) } = 1.
 
 % Auxiliary values for (non-numeric) constants
 value(P,P) :- constant(P).

--- a/examples/config/base/structure.lp
+++ b/examples/config/base/structure.lp
@@ -4,10 +4,10 @@ include("root").
 % Generate include predicates for objects
 { include(X) : type(X,_) }.
 
-% Always include minimal number of objects
-% Commented out because we wanted to include no optimizations currently
-% include(X) :- feature(C,_,T,Min,_), type(X,T), index(X,I), I < Min,
-%                parent(X,P), include(P), type(P,C).
+%% Always include minimal number of objects
+%% Commented out because we wanted to include no optimizations currently
+%% include(X) :- feature(C,_,T,Min,_), type(X,T), index(X,I), I < Min,
+%%                parent(X,P), include(P), type(P,C).
 
 % Do not include an object if its parent is not included
 :- include(X), parent(X,P), not include(P).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ Homepage = "https://github.com/potassco/mkdoclingo.git/"
 [project.optional-dependencies]
 format = ["black", "isort", "autoflake"]
 lint_pylint = ["pylint", "djlint"]
-typecheck = ["types-setuptools", "mypy", "types-Markdown"]
+typecheck = ["types-setuptools", "mypy", "types-Markdown", "types-Pygments"]
 test = ["coverage[toml]", "pytest"]
 doc = ["mkdocstrings[python]", "mkdocs-literate-nav"]
 dev = ["mkdoclingo[test,typecheck,lint_pylint,doc]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "clingo",
     "mkdocstrings>=1.0.0",
     "tree-sitter",
-    "tree-sitter-clingo>=1.0.3",
+    "tree-sitter-clingo>=1.0.5",
     "pydantic",
     "pygments_clingo",
     "mkdocs>=1.5",

--- a/src/mkdocstrings_handlers/asp/_internal/collect/extractors.py
+++ b/src/mkdocstrings_handlers/asp/_internal/collect/extractors.py
@@ -93,7 +93,7 @@ def extract_include(node: Node, parent_file_path: Path) -> Include:
     return Include((parent_file_path.parent / file_path))
 
 
-def extract_predicate(node: Node) -> Predicate:
+def extract_predicates(node: Node) -> list[Predicate]:
     """
     Extract a Predicate from a node.
 
@@ -105,11 +105,19 @@ def extract_predicate(node: Node) -> Predicate:
     """
     captures = Queries.PREDICATE.captures(node)
 
-    return Predicate(
-        identifier=get_node_text(captures["identifier"][0]),
-        arity=len(captures.get("term", [])),
-        negation=len(captures.get("negation", [])) > 0,
-    )
+    identifier = get_node_text(captures["identifier"][0])
+    is_negated = len(captures.get("negation", [])) > 0
+
+    if "term_group" not in captures:
+        return [Predicate(identifier=identifier, arity=0, negation=is_negated)]
+
+    predicates = []
+    for group_node in captures["term_group"]:
+        arity = group_node.named_child_count
+
+        predicates.append(Predicate(identifier=identifier, arity=arity, negation=is_negated))
+
+    return predicates
 
 
 def extract_show(node: Node) -> Show:
@@ -209,8 +217,8 @@ def extract_statement(node: Node) -> Statement:
         for key, nodes in body_captures.items():
             captures[key].extend(nodes)
 
-    provided_predicates = [extract_predicate(node) for node in captures.get("provided", [])]
-    needed_predicates = [extract_predicate(node) for node in captures.get("needed", [])]
+    provided_predicates = [pred for node in captures.get("provided", []) for pred in extract_predicates(node)]
+    needed_predicates = [pred for node in captures.get("needed", []) for pred in extract_predicates(node)]
 
     return Statement(
         row=node.start_point.row,

--- a/src/mkdocstrings_handlers/asp/_internal/collect/extractors.py
+++ b/src/mkdocstrings_handlers/asp/_internal/collect/extractors.py
@@ -89,8 +89,9 @@ def extract_include(node: Node, parent_file_path: Path) -> Include:
     # as a string fragment without the quotes.
     file_path_node = node.children[1]
     file_path = Path(get_node_text(file_path_node.children[1]))
+    resolved_path = parent_file_path.parent / file_path
 
-    return Include((parent_file_path.parent / file_path))
+    return Include(row=node.start_point.row, content=get_node_text(node), path=resolved_path)
 
 
 def extract_predicates(node: Node) -> list[Predicate]:
@@ -152,6 +153,8 @@ def extract_show(node: Node) -> Show:
         )
 
     return Show(
+        row=node.start_point.row,
+        content=get_node_text(node),
         predicate=predicate,
         status=status,
     )
@@ -186,6 +189,24 @@ def extract_block_comment(node: Node) -> BlockComment:
     return BlockComment(
         row=node.start_point.row,
         content=get_node_text(node).removeprefix("%*").removesuffix("*%"),
+    )
+
+
+def extract_bare_statement(node: Node) -> Statement:
+    """
+    Extract a Statement without predicate tracking.
+
+    Args:
+        node: A node representing the statement.
+
+    Returns:
+        The created Statement.
+    """
+    return Statement(
+        row=node.start_point.row,
+        content=get_node_text(node),
+        provided_predicates=[],
+        needed_predicates=[],
     )
 
 

--- a/src/mkdocstrings_handlers/asp/_internal/collect/load.py
+++ b/src/mkdocstrings_handlers/asp/_internal/collect/load.py
@@ -5,6 +5,7 @@ from collections import deque
 from pathlib import Path
 
 from mkdocstrings_handlers.asp._internal.collect.extractors import (
+    extract_bare_statement,
     extract_block_comment,
     extract_include,
     extract_line_comment,
@@ -84,5 +85,8 @@ def load_document(file_path: Path) -> Document:
             case NodeKind.DOC_COMMENT:
                 predicate_documentation = extract_predicate_documentation(node)
                 document.predicate_documentations.append(predicate_documentation)
+            case _:
+                statement = extract_bare_statement(node)
+                document.statements.append(statement)
 
     return document

--- a/src/mkdocstrings_handlers/asp/_internal/collect/queries/predicate.scm
+++ b/src/mkdocstrings_handlers/asp/_internal/collect/queries/predicate.scm
@@ -12,7 +12,7 @@
         (identifier) @identifier
         (terms
             (_) @term
-        )?
+        )? @term_group
     )
 )
 
@@ -24,6 +24,6 @@
         (identifier) @identifier
         (terms
             (_) @term
-        )?
+        )? @term_group
     )
 )

--- a/src/mkdocstrings_handlers/asp/_internal/config.py
+++ b/src/mkdocstrings_handlers/asp/_internal/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Mapping
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
@@ -67,6 +68,8 @@ class ASPOptions(BaseModel):
     glossary: GlossaryOptions = Field(default_factory=GlossaryOptions)
     predicate_table: PredicateTableOptions = Field(default_factory=PredicateTableOptions)
     dependency_graph: DependencyGraphOptions = Field(default_factory=DependencyGraphOptions)
+    extra_includes: list[Path] = Field(default_factory=list)
+    """ Additional files to include in the documentation. """
 
     @model_validator(mode="before")
     @classmethod

--- a/src/mkdocstrings_handlers/asp/_internal/domain.py
+++ b/src/mkdocstrings_handlers/asp/_internal/domain.py
@@ -8,7 +8,17 @@ from pathlib import Path
 
 
 @dataclass
-class Include:
+class LocatedContent:
+    """Source content tracked with its row in the file."""
+
+    row: int
+    """ The row in the source file where the fragment is located. """
+    content: str
+    """ The original content of the fragment. """
+
+
+@dataclass
+class Include(LocatedContent):
     """An include directive in an ASP document."""
 
     path: Path
@@ -31,7 +41,7 @@ class ShowStatus(IntFlag):
 
 
 @dataclass
-class Show:
+class Show(LocatedContent):
     """A show directive in an ASP document."""
 
     predicate: Predicate | None
@@ -66,33 +76,19 @@ class Predicate:
 
 
 @dataclass
-class LineComment:
+class LineComment(LocatedContent):
     """A line comment in an ASP program."""
 
-    row: int
-    """ The row in the source file where the comment is located."""
-    content: str
-    """ The content of the line comment."""
-
 
 @dataclass
-class BlockComment:
+class BlockComment(LocatedContent):
     """A block comment in an ASP program."""
 
-    row: int
-    """ The row in the source file where the comment starts."""
-    content: str
-    """ The content of the block comment."""
-
 
 @dataclass
-class Statement:
+class Statement(LocatedContent):
     """A statement in an ASP program."""
 
-    row: int
-    """The row in the source file where the statement is located."""
-    content: str
-    """The content of the statement."""
     provided_predicates: list[Predicate]
     """The predicates provided by the statement."""
     needed_predicates: list[Predicate]
@@ -110,13 +106,9 @@ class ArgumentDocumentation:
 
 
 @dataclass
-class PredicateDocumentation:
+class PredicateDocumentation(LocatedContent):
     """Documentation for a predicate."""
 
-    row: int
-    """ The row in the source file where the documentation is located. """
-    content: str
-    """ The entire content of the documentation. """
     signature: str
     """ The signature of the predicate being documented. """
     description: str

--- a/src/mkdocstrings_handlers/asp/_internal/handler.py
+++ b/src/mkdocstrings_handlers/asp/_internal/handler.py
@@ -85,7 +85,10 @@ class ASPHandler(BaseHandler):
             The collected data as a dictionary.
         """
 
-        return load_documents([Path(identifier)])
+        document_paths = options.extra_includes
+        document_paths.append(Path(identifier))
+
+        return load_documents(document_paths)
 
     def render(self, data: list[Document], options: ASPOptions, **_kwargs: Any) -> str:
         """

--- a/src/mkdocstrings_handlers/asp/_internal/render/encodings_context.py
+++ b/src/mkdocstrings_handlers/asp/_internal/render/encodings_context.py
@@ -5,7 +5,12 @@ from enum import Enum, auto
 from urllib.parse import urljoin
 
 from mkdocstrings_handlers.asp._internal.config import ASPOptions
-from mkdocstrings_handlers.asp._internal.domain import BlockComment, Document, LineComment, Statement
+from mkdocstrings_handlers.asp._internal.domain import (
+    Document,
+    Include,
+    LocatedContent,
+    Statement,
+)
 
 
 class BlockType(Enum):
@@ -62,7 +67,9 @@ def get_encoding_context(documents: list[Document], options: ASPOptions) -> Enco
     encodings = []
 
     for document in documents:
-        ordered_elements: list[Statement | LineComment | BlockComment] = list(document.statements)
+        ordered_elements: list[LocatedContent] = list(document.includes)
+
+        ordered_elements.extend(document.statements)
 
         ordered_elements.extend(document.block_comments)
 
@@ -86,7 +93,7 @@ def get_encoding_context(documents: list[Document], options: ASPOptions) -> Enco
         current_block_type = BlockType.MARKDOWN
 
         for element in ordered_elements:
-            if isinstance(element, Statement):
+            if isinstance(element, (Statement, Include)):
                 if current_block_type != BlockType.CODE:
                     if current_block_content:
                         encoding.blocks.append(

--- a/src/mkdocstrings_handlers/asp/_internal/render/encodings_context.py
+++ b/src/mkdocstrings_handlers/asp/_internal/render/encodings_context.py
@@ -5,7 +5,7 @@ from enum import Enum, auto
 from urllib.parse import urljoin
 
 from mkdocstrings_handlers.asp._internal.config import ASPOptions
-from mkdocstrings_handlers.asp._internal.domain import Document, Statement
+from mkdocstrings_handlers.asp._internal.domain import BlockComment, Document, LineComment, Statement
 
 
 class BlockType(Enum):
@@ -62,7 +62,16 @@ def get_encoding_context(documents: list[Document], options: ASPOptions) -> Enco
     encodings = []
 
     for document in documents:
-        ordered_elements = document.statements + document.line_comments + document.block_comments
+        ordered_elements: list[Statement | LineComment | BlockComment] = list(document.statements)
+
+        ordered_elements.extend(document.block_comments)
+
+        for line_comment in document.line_comments:
+            content = line_comment.content.strip()
+            if content.startswith("%"):
+                continue
+            ordered_elements.append(line_comment)
+
         ordered_elements.sort(key=lambda element: element.row)
 
         repository_url = None

--- a/src/mkdocstrings_handlers/asp/_internal/render/glossary_context.py
+++ b/src/mkdocstrings_handlers/asp/_internal/render/glossary_context.py
@@ -2,8 +2,14 @@
 
 from dataclasses import dataclass, field
 
+from pygments import highlight
+from pygments.formatters.html import HtmlFormatter
+from pygments.lexers import get_lexer_by_name
+
 from mkdocstrings_handlers.asp._internal.domain import ShowStatus
 from mkdocstrings_handlers.asp._internal.render.predicate_info import PredicateInfo
+
+LEXER = get_lexer_by_name("clingo")
 
 
 @dataclass
@@ -16,6 +22,7 @@ class GlossaryReference:
     """ The content of the line where the reference is found. """
     is_providing: bool
     """ Whether this reference is a definition (providing) or just a usage (not providing). """
+    html_content: str = ""
 
 
 @dataclass
@@ -60,8 +67,12 @@ def _add_reference_to_map(
     if path not in file_row_map:
         file_row_map[path] = {}
 
+    formatter = HtmlFormatter(nowrap=True, hl_lines=[1] if is_providing else [])
     if row not in file_row_map[path]:
-        file_row_map[path][row] = GlossaryReference(row=row, content=content, is_providing=is_providing)
+        highlighted = highlight(content, LEXER, formatter)
+        file_row_map[path][row] = GlossaryReference(
+            row=row, content=content, is_providing=is_providing, html_content=highlighted
+        )
 
 
 def get_glossary_context(predicates: list[PredicateInfo]) -> GlossaryContext:

--- a/src/mkdocstrings_handlers/asp/_internal/render/glossary_context.py
+++ b/src/mkdocstrings_handlers/asp/_internal/render/glossary_context.py
@@ -1,6 +1,7 @@
 """This module defines the glossary context for rendering."""
 
 from dataclasses import dataclass, field
+from os.path import commonpath, dirname, relpath
 
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
@@ -85,6 +86,17 @@ def get_glossary_context(predicates: list[PredicateInfo]) -> GlossaryContext:
     Returns:
         The constructed GlossaryContext.
     """
+    unique_paths = {d.path for p in predicates for d in p.definitions}
+    unique_paths.update(r.path for p in predicates for r in p.references)
+
+    all_raw_paths = list(unique_paths)
+
+    project_root = ""
+    if len(all_raw_paths) > 1:
+        project_root = commonpath(all_raw_paths)
+    elif len(all_raw_paths) == 1:
+        project_root = dirname(all_raw_paths[0])
+
     result: list[GlossaryPredicate] = []
 
     for predicate in predicates:
@@ -101,7 +113,9 @@ def get_glossary_context(predicates: list[PredicateInfo]) -> GlossaryContext:
             references = list(row_map.values())
             references.sort(key=lambda ref: ref.row)
 
-            file_references.append(FileReference(path=path, references=references))
+            display_path = relpath(path, project_root).replace("\\", "/")
+
+            file_references.append(FileReference(path=display_path, references=references))
 
         file_references.sort(key=lambda file: file.path)
 

--- a/src/mkdocstrings_handlers/asp/_internal/render/predicate_info.py
+++ b/src/mkdocstrings_handlers/asp/_internal/render/predicate_info.py
@@ -36,6 +36,11 @@ class PredicateInfo:
 
     signature: str
     """ The signature of the predicate, e.g., "parent/2". """
+    summary: str = ""
+    """ A short summary of the predicate.
+
+    This is the first line of the description, up to the first period.
+    """
     description: str = ""
     """ The description of the predicate. """
     arguments: list[ArgumentInfo] = field(default_factory=list)
@@ -131,6 +136,7 @@ def get_predicate_infos(documents: list[Document], options: ASPOptions) -> list[
         for documentation in document.predicate_documentations:
             predicate_info = get_info(documentation.signature)
 
+            predicate_info.summary = documentation.description.split(".")[0] if documentation.description else ""
             predicate_info.description = documentation.description
             predicate_info.arguments = [
                 ArgumentInfo(

--- a/src/mkdocstrings_handlers/asp/templates/material/glossary.html.jinja
+++ b/src/mkdocstrings_handlers/asp/templates/material/glossary.html.jinja
@@ -13,6 +13,8 @@
   {% set pred_sig %}
     <code class="doc-symbol doc-symbol-heading doc-clingo-symbol-predicate"
           style="font-size: 0.6rem"></code>
+    {{ input_icon_map[predicate.is_input]|safe }}
+    {{ show_icon_map[predicate.show_status]|safe }}
     <code style="font-size: 0.6rem;">{{ predicate }}</code>
   {% endset %}
   {% set predicate_id = predicate.signature | replace("/", "-") %}

--- a/src/mkdocstrings_handlers/asp/templates/material/glossary.html.jinja
+++ b/src/mkdocstrings_handlers/asp/templates/material/glossary.html.jinja
@@ -25,7 +25,7 @@
             style="font-size: 0.6rem"></code>
       {{ input_icon_map[predicate.is_input]|safe }}
       {{ show_icon_map[predicate.show_status]|safe }}
-      <code style="font-size: 0.6rem;">{{ predicate }}</code>
+      <code style="font-size: 0.6rem;">{{ predicate.signature }}</code>
     </span>
   {% endset %}
   {% filter heading(context.options.start_level+2, id=predicate_id, toc_label=pred_toc) %}

--- a/src/mkdocstrings_handlers/asp/templates/material/glossary_references.html.jinja
+++ b/src/mkdocstrings_handlers/asp/templates/material/glossary_references.html.jinja
@@ -13,7 +13,7 @@
     <div class="tabbed-labels tabbed-labels--linked">
       {% for file in glossary_predicate.files %}
         <label for="__tabbed-{{ predicate_id }}-{{ loop.index }}">
-          <code>{{ file.filename }}</code>
+          <code>{{ file.path }}</code>
         </label>
       {% endfor %}
     </div>
@@ -21,8 +21,22 @@
       {% for file in glossary_predicate.files %}
         <div class="tabbed-block">
           {% for reference in file.references %}
-            {% set hl_attr = ' hl_lines="1"' if reference.is_providing else '' %}
-            {{ ('```clingo linenums="' ~ (reference.row + 1) ~ '"' ~ hl_attr ~ '\n' ~ reference.content ~ '\n```') | convert_markdown(0) }}
+            <div class="highlight">
+              <table class="highlighttable">
+                <tr>
+                  <td class="linenos">
+                    <div class="linenodiv">
+                      <pre><span>{{ reference.row + 1 }}</span></pre>
+                    </div>
+                  </td>
+                  <td class="code">
+                    <div class="highlight">
+                      <pre><code>{{ reference.html_content | safe }}</code></pre>
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </div>
           {% endfor %}
         </div>
       {% endfor %}

--- a/src/mkdocstrings_handlers/asp/templates/material/predicate_table.html.jinja
+++ b/src/mkdocstrings_handlers/asp/templates/material/predicate_table.html.jinja
@@ -26,7 +26,7 @@
           <td>
             <a href="#{{ predicate_id }}"><code>{{ predicate.signature }}</code></a>
           </td>
-          <td>{{ predicate.description | convert_markdown(5, html_id) }}</td>
+          <td>{{ predicate.summary | convert_markdown(5, html_id) }}</td>
           <td style="padding-top: 0; padding-bottom: 0;">
             {{ input_icon_map[predicate.is_input] }} {{ show_icon_map[predicate.show_status] }}
           </td>

--- a/tests/collect/test_extractors.py
+++ b/tests/collect/test_extractors.py
@@ -13,8 +13,8 @@ from mkdocstrings_handlers.asp._internal.collect.extractors import (
     extract_block_comment,
     extract_include,
     extract_line_comment,
-    extract_predicate,
     extract_predicate_documentation,
+    extract_predicates,
     extract_show,
     extract_statement,
     get_capture_text,
@@ -119,11 +119,11 @@ def test_extract_predicate(parse_to_tree: Callable[[str], Tree]) -> None:
     literal_node = rule_node.child(0)
     assert literal_node is not None
 
-    predicate = extract_predicate(literal_node)
+    predicates = extract_predicates(literal_node)
 
-    assert predicate.identifier == "p"
-    assert predicate.arity == 5
-    assert predicate.negation is False
+    assert predicates[0].identifier == "p"
+    assert predicates[0].arity == 5
+    assert predicates[0].negation is False
 
 
 def test_extract_predicate_without_terms(parse_to_tree: Callable[[str], Tree]) -> None:
@@ -137,11 +137,33 @@ def test_extract_predicate_without_terms(parse_to_tree: Callable[[str], Tree]) -
 
     literal_node = rule_node.child(0)
     assert literal_node is not None
-    predicate = extract_predicate(literal_node)
+    predicates = extract_predicates(literal_node)
 
-    assert predicate.identifier == "p"
-    assert predicate.arity == 0
-    assert predicate.negation is False
+    assert predicates[0].identifier == "p"
+    assert predicates[0].arity == 0
+    assert predicates[0].negation is False
+
+
+def test_extract_predicate_with_pool(parse_to_tree: Callable[[str], Tree]) -> None:
+    """Test extracting a Predicate with a pool of terms from a literal node."""
+
+    source = "p(a,b;c,d,e)."
+    tree = parse_to_tree(source)
+
+    rule_node = tree.root_node.child(0)
+    assert rule_node is not None
+
+    literal_node = rule_node.child(0)
+    assert literal_node is not None
+    predicate = extract_predicates(literal_node)
+
+    assert predicate[0].identifier == "p"
+    assert predicate[0].arity == 2
+    assert predicate[0].negation is False
+
+    assert predicate[1].identifier == "p"
+    assert predicate[1].arity == 3
+    assert predicate[1].negation is False
 
 
 def test_extract_predicate_negative(parse_to_tree: Callable[[str], Tree]) -> None:
@@ -154,11 +176,11 @@ def test_extract_predicate_negative(parse_to_tree: Callable[[str], Tree]) -> Non
 
     literal_node = rule_node.child(0)
     assert literal_node is not None
-    predicate = extract_predicate(literal_node)
+    predicates = extract_predicates(literal_node)
 
-    assert predicate.identifier == "p"
-    assert predicate.arity == 2
-    assert predicate.negation is True
+    assert predicates[0].identifier == "p"
+    assert predicates[0].arity == 2
+    assert predicates[0].negation is True
 
 
 def test_extract_predicate_from_body_literal(parse_to_tree: Callable[[str], Tree]) -> None:
@@ -175,11 +197,11 @@ def test_extract_predicate_from_body_literal(parse_to_tree: Callable[[str], Tree
     literal_node = body_node.child(0)
     assert literal_node is not None
 
-    predicate = extract_predicate(literal_node)
+    predicates = extract_predicates(literal_node)
 
-    assert predicate.identifier == "q"
-    assert predicate.arity == 2
-    assert predicate.negation is True
+    assert predicates[0].identifier == "q"
+    assert predicates[0].arity == 2
+    assert predicates[0].negation is True
 
 
 def test_extract_line_comment(parse_to_tree: Callable[[str], Tree]) -> None:

--- a/tests/collect/test_extractors.py
+++ b/tests/collect/test_extractors.py
@@ -10,6 +10,7 @@ from tree_sitter import Node, Tree
 
 from mkdocstrings_handlers.asp._internal.collect.extractors import (
     extract_argument_documentation,
+    extract_bare_statement,
     extract_block_comment,
     extract_include,
     extract_line_comment,
@@ -104,6 +105,8 @@ def test_extract_include(tmp_path: Path, parse_to_tree: Callable[[str], Tree]) -
 
     include = extract_include(include_node, parent_file_path=parent_file)
 
+    assert include.row == 0
+    assert include.content == source
     assert include.path == included_file
 
 
@@ -242,6 +245,8 @@ def test_extract_show_empty(parse_to_tree: Callable[[str], Tree]) -> None:
 
     show = extract_show(show_node)
 
+    assert show.row == 0
+    assert show.content == source
     assert show.predicate is None
     assert show.status == ShowStatus.EXPLICIT
 
@@ -256,6 +261,8 @@ def test_extract_show_signature(parse_to_tree: Callable[[str], Tree]) -> None:
 
     show = extract_show(show_node)
 
+    assert show.row == 0
+    assert show.content == source
     assert show.predicate is not None
     assert show.predicate.identifier == "p"
     assert show.predicate.arity == 2
@@ -272,6 +279,8 @@ def test_extract_show_term_function(parse_to_tree: Callable[[str], Tree]) -> Non
 
     show = extract_show(show_node)
 
+    assert show.row == 0
+    assert show.content == source
     assert show.predicate is not None
     assert show.predicate.identifier == "p"
     assert show.predicate.arity == 2
@@ -452,6 +461,22 @@ def test_extract_statement_with_comparison(parse_to_tree: Callable[[str], Tree])
     assert statement.content == source
     assert len(statement.provided_predicates) == 0
     assert len(statement.needed_predicates) == 2
+
+
+def test_extract_bare_statement_for_unsupported_directive(parse_to_tree: Callable[[str], Tree]) -> None:
+    """Test extracting a bare Statement from an unsupported directive."""
+
+    source = "#external p(X) : q(X)."
+    tree = parse_to_tree(source)
+    directive_node = tree.root_node.child(0)
+    assert directive_node is not None
+
+    statement = extract_bare_statement(directive_node)
+
+    assert statement.row == 0
+    assert statement.content == source
+    assert len(statement.provided_predicates) == 0
+    assert len(statement.needed_predicates) == 0
 
 
 def test_extract_argument_documentation(parse_to_tree: Callable[[str], Tree]) -> None:

--- a/tests/collect/test_load.py
+++ b/tests/collect/test_load.py
@@ -32,6 +32,7 @@ def test_load_from_file(tmp_path: Path) -> None:
     assert len(document.block_comments) == 0
     assert len(document.predicate_documentations) == 1
     assert len(document.shows) == 2
+    assert [show.content for show in document.shows] == ["#show q/1.", "#show p(1,2)."]
     assert document.shows[0].status == ShowStatus.EXPLICIT
     assert document.shows[1].status == ShowStatus.PARTIAL
 
@@ -52,6 +53,25 @@ def test_load_from_file_empty(tmp_path: Path) -> None:
     assert len(document.line_comments) == 0
     assert len(document.block_comments) == 0
     assert len(document.predicate_documentations) == 0
+
+
+def test_load_from_file_with_unsupported_directives(tmp_path: Path) -> None:
+    """Test that unsupported directives are preserved as bare statements."""
+
+    file_path = tmp_path / "directives.lp"
+    file_content = "#const n=3.\n#external p(X) : q(X).\nr(X) :- q(X).\n"
+    file_path.write_text(file_content, encoding="utf-8")
+
+    document = load_document(file_path)
+
+    assert [statement.content for statement in document.statements] == [
+        "#const n=3.",
+        "#external p(X) : q(X).",
+        "r(X) :- q(X).",
+    ]
+    assert len(document.statements) == 3
+    assert len(document.statements[2].provided_predicates) == 1
+    assert len(document.statements[2].needed_predicates) == 1
 
 
 def test_load_from_files(tmp_path: Path) -> None:
@@ -90,6 +110,7 @@ def test_load_from_files(tmp_path: Path) -> None:
     assert len(document.line_comments) == 2
     assert len(document.block_comments) == 1
     assert len(document.predicate_documentations) == 0
+    assert document.includes[0].content == '#include "includes/included_file.lp".'
     assert document.includes[0].path == included_file_path
 
     included_document = next(doc for doc in documents if doc.path == included_file_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,3 +43,21 @@ def render_context(tmp_path: Path) -> Callable[[str], RenderContext]:
         return RenderContext(documents=documents, options=options)
 
     return _render_context
+
+
+@pytest.fixture
+def multi_file_render_context(tmp_path: Path) -> Callable[[list[str]], RenderContext]:
+    """Helper to create a RenderContext from given file content."""
+
+    def _render_context(file_contents: list[str]) -> RenderContext:
+        file_paths = []
+        for i, content in enumerate(file_contents):
+            file_path = tmp_path / f"test_{i}.lp"
+            file_path.write_text(content, encoding="utf-8")
+            file_paths.append(file_path)
+
+        documents = load_documents(file_paths)
+        options = ASPOptions()
+        return RenderContext(documents=documents, options=options)
+
+    return _render_context

--- a/tests/render/test_encodings_context.py
+++ b/tests/render/test_encodings_context.py
@@ -47,6 +47,27 @@ def test_get_encodings_context_with_comments(render_context: Callable[[str], Ren
     assert len(encoding_info.blocks) == 4
 
 
+def test_get_encodings_context_with_ignored_content(render_context: Callable[[str], RenderContext]) -> None:
+    """Test that the encodings context is built correctly with ignored content."""
+
+    source = """
+    % rules
+    output_pred(X) :- shown_input_pred(X).
+    % % This should be ignored
+    internal_calc(X) :- hidden_input_pred(X).
+    % show statements
+    #show output_pred/1.
+    #show shown_input_pred/1.
+    """
+
+    context = render_context(source)
+
+    assert len(context.encodings.entries) == 1
+    encoding_info = context.encodings.entries[0]
+    assert encoding_info.source.splitlines() == source.splitlines()
+    assert len(encoding_info.blocks) == 4
+
+
 @pytest.mark.parametrize(
     ("repo_url", "file_path", "expected_url"),
     [

--- a/tests/render/test_encodings_context.py
+++ b/tests/render/test_encodings_context.py
@@ -68,6 +68,48 @@ def test_get_encodings_context_with_ignored_content(render_context: Callable[[st
     assert len(encoding_info.blocks) == 4
 
 
+def test_get_encodings_context_with_unsupported_directives(render_context: Callable[[str], RenderContext]) -> None:
+    """Test that unsupported directives still appear in the encoding code blocks."""
+
+    source = """
+    #const n=3.
+    #external p(X) : q(X).
+    r(X) :- q(X).
+    """
+
+    context = render_context(source)
+
+    assert len(context.encodings.entries) == 1
+    encoding_info = context.encodings.entries[0]
+    assert len(encoding_info.blocks) == 1
+    assert encoding_info.blocks[0].content.splitlines() == [
+        "#const n=3.",
+        "#external p(X) : q(X).",
+        "r(X) :- q(X).",
+    ]
+
+
+def test_get_encodings_context_with_include_and_show(render_context: Callable[[str], RenderContext]) -> None:
+    """Test that includes render as code and shows remain part of the code block."""
+
+    source = """
+    #include "parts/base.lp".
+    p(X) :- q(X).
+    #show p/1.
+    """
+
+    context = render_context(source)
+
+    assert len(context.encodings.entries) == 1
+    encoding_info = context.encodings.entries[0]
+    assert len(encoding_info.blocks) == 1
+    assert encoding_info.blocks[0].content.splitlines() == [
+        '#include "parts/base.lp".',
+        "p(X) :- q(X).",
+        "#show p/1.",
+    ]
+
+
 @pytest.mark.parametrize(
     ("repo_url", "file_path", "expected_url"),
     [

--- a/tests/render/test_glossary_context.py
+++ b/tests/render/test_glossary_context.py
@@ -54,3 +54,24 @@ def test_get_glossary_context_not_show_undocumented(render_context: Callable[[st
     context.options.predicate_info.include_undocumented = False
 
     assert len(context.glossary.predicates) == 0
+
+
+def test_get_glossary_context_predicate_in_multiple_files(
+    multi_file_render_context: Callable[[list[str]], RenderContext],
+) -> None:
+    """Test that predicates defined in multiple files are handled correctly."""
+
+    context = multi_file_render_context(
+        [
+            """
+            q(1).
+            """,
+            """
+            q(2).
+            """,
+        ]
+    )
+
+    assert len(context.glossary.predicates) == 1
+    assert context.glossary.predicates[0].files[0].path == "test_0.lp"
+    assert context.glossary.predicates[0].files[1].path == "test_1.lp"

--- a/tests/render/test_predicate_info.py
+++ b/tests/render/test_predicate_info.py
@@ -115,3 +115,20 @@ def test_get_predicate_info_filter_hidden(render_context: Callable[[str], Render
     context.options.predicate_info.include_hidden = False
 
     assert len(context.glossary.predicates) == 2
+
+
+def test_get_predicate_info_with_pools(render_context: Callable[[str], RenderContext]) -> None:
+    """Test that predicates with pools are handled correctly."""
+
+    context = render_context(
+        """
+    some_predicate(a,b;c,d,e).
+    """
+    )
+
+    context.options.predicate_info.include_hidden = True
+
+    predicate_info = context._predicates[0]
+    assert predicate_info.signature == "some_predicate/2"
+    predicate_info = context._predicates[1]
+    assert predicate_info.signature == "some_predicate/3"


### PR DESCRIPTION
This makes the predicate table use the first sentence of a predicate's doc string as the description, instead of the entire thing.

It now also:
- Fixes #58
- Fixes #59
- Fixes #60
- Fixes #61
- Fixes #62 
- Fixes #63
- Fixes #65
- Fixes #66 
